### PR TITLE
增加反向代理到公网80端口, 用于调试公众号

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 node_modules/
 /dist/
+/dist*.tar
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -38,12 +38,20 @@ npm test
 
 For a detailed explanation on how things work, check out the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
 
-# Run on nginx(docker)
+# Run on nginx (docker)
 ``` bash
 1. 先执行 Ready Env 中的步骤
 2. npm run build    # build for production with minification
 3. tar cvf dist.tar dist/; # 上传dist.tar到服务器
 4. jieya dist.tar; chown -R root:root dist
-5. docker-compose up -d
+5. docker-compose up
 6. echo $API_URL:80/index.html # 浏览器访问地址
+```
+
+# 公众号透传给内网机器测试
+``` bash
+# 用法: ssh -NfR 公网主机port:内网主机ip:内网主机port <用户名>@公网主机ip -p 公网主机ssh端口
+export ECS_IP='your_ecs_ip'
+ssh -NfR  80:localhost:80  root@${ECS_IP}  -p 22
+ps -ef | grep ssh | grep NfR | awk  '{print $2}' | xargs kill
 ```

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 ## Ready Env
 ``` bash
+rpm -i  direnv-stable-linux-amd64.rpm
 cp  docker/example.envrc  .envec
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # myvue
 > A Vue.js project
 
-## Build Setup
+## Ready Env
 ``` bash
 cp  docker/example.envrc  .envec
+```
+
+## Build Setup
+``` bash
 
 # install dependencies. 安装package.json文件中制定的依赖:
-npm install
+1. npm install
 
 # serve with hot reload at localhost:8080
-HOST='0.0.0.0' npm run dev
+2. HOST='0.0.0.0' npm run dev
 浏览器访问 http://localhost:8080/#/
 
 # build for production and view the bundle analyzer report
@@ -29,12 +33,9 @@ For a detailed explanation on how things work, check out the [guide](http://vuej
 
 # Run on nginx(docker)
 ``` bash
-# build for production with minification
-npm run build
-
-tar cvf dist.tar dist/; # 上传dist.tar到服务器
-
-docker-compose up -d
-
-echo $API_URL:8000/index.html # 浏览器访问地址
+1. 先执行 Ready Env 中的步骤
+2. npm run build    # build for production with minification
+3. tar cvf dist.tar dist/; # 上传dist.tar到服务器
+4. docker-compose up -d
+5. echo $API_URL:8000/index.html # 浏览器访问地址
 ```

--- a/README.md
+++ b/README.md
@@ -1,19 +1,16 @@
 # myvue
-
 > A Vue.js project
 
 ## Build Setup
-
 ``` bash
+cp  docker/example.envrc  .envec
+
 # install dependencies. 安装package.json文件中制定的依赖:
 npm install
 
 # serve with hot reload at localhost:8080
 HOST='0.0.0.0' npm run dev
 浏览器访问 http://localhost:8080/#/
-
-# build for production with minification
-npm run build
 
 # build for production and view the bundle analyzer report
 npm run build --report
@@ -30,8 +27,14 @@ npm test
 
 For a detailed explanation on how things work, check out the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
 
-# Run dist in nginx
+# Run on nginx(docker)
 ``` bash
-$ docker-compose up
-浏览器访问 http://localhost:8080/index.html
+# build for production with minification
+npm run build
+
+tar cvf dist.tar dist/; # 上传dist.tar到服务器
+
+docker-compose up -d
+
+echo $API_URL:8000/index.html # 浏览器访问地址
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ``` bash
 rpm -i  direnv-stable-linux-amd64.rpm
 cp  docker/example.envrc  .envec
+direnv allow .
 ```
 
 ## Build Setup

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 rpm -i  direnv-stable-linux-amd64.rpm
 cp  docker/example.envrc  .envec
 direnv allow .
+
+# CentOS 7 docker 权限问题
+su -c "setenforce 0"
+或者添加 selinux 规则:
+chcon -Rt svirt_sandbox_file_t /path/to/volume
 ```
 
 ## Build Setup
@@ -38,6 +43,7 @@ For a detailed explanation on how things work, check out the [guide](http://vuej
 1. 先执行 Ready Env 中的步骤
 2. npm run build    # build for production with minification
 3. tar cvf dist.tar dist/; # 上传dist.tar到服务器
-4. docker-compose up -d
-5. echo $API_URL:8000/index.html # 浏览器访问地址
+4. jieya dist.tar; chown -R root:root dist
+5. docker-compose up -d
+6. echo $API_URL:80/index.html # 浏览器访问地址
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: vue_nginx
 
     ports:      # 外部端口:docker内部端口
-      - "8080:80"       # 只限于使用docker-compse up时, 会映射到8000端口, 而生产会映射到80端口
+      - "8000:80"       # 只限于使用docker-compse up时, 会映射到8000端口, 而生产会映射到80端口
 
     volumes:        # 挂载盘(多用于输出程序文件, 日志等)
       - ./dist:/usr/share/nginx/html:ro     # readonly解释: https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     container_name: vue_nginx
 
     ports:      # 外部端口:docker内部端口
-      - "8000:80"       # 只限于使用docker-compse up时, 会映射到8000端口, 而生产会映射到80端口
+      - "80:80"       # 只限于使用docker-compse up时, 会映射到8000端口, 而生产会映射到80端口
 
     volumes:        # 挂载盘(多用于输出程序文件, 日志等)
-      - ./dist:/usr/share/nginx/html:ro     # readonly解释: https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag
+      - ./dist:/usr/share/nginx/html:ro     # :ro模式: (readonly) https://docs.docker.com/storage/volumes/#choose-the--v-or---mount-flag

--- a/docker/docker.sh
+++ b/docker/docker.sh
@@ -1,2 +1,2 @@
 # https://hub.docker.com/_/nginx/
-docker run --name vue-nginx -d -p 8080:80 nginx:1.13.12-alpine
+docker run --name vue-nginx -d -p 80:80 nginx:1.13.12-alpine

--- a/docker/example.envrc
+++ b/docker/example.envrc
@@ -1,1 +1,2 @@
 export API_URL='http://www.your_domain.com'
+export ECS_IP='your_ecs_ip'

--- a/docker/example.envrc
+++ b/docker/example.envrc
@@ -1,0 +1,1 @@
+export API_URL='http://www.your_domain.com'


### PR DESCRIPTION
1. 由8080端口改为80端口
2. 完善README.md